### PR TITLE
add optional og:type and twitter:card

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -11,6 +11,9 @@ use Mix.Config
 # You can configure your application as:
 #
 #     config :phoenix_meta_tags, key: :value
+config :phoenix_meta_tags,
+  "og:type": "website",
+  "twitter:card": "summary_large_image"
 #
 # and access this configuration in your application as:
 #

--- a/lib/meta_tags/phoenix_meta_tags_view.ex
+++ b/lib/meta_tags/phoenix_meta_tags_view.ex
@@ -50,7 +50,7 @@ defmodule PhoenixMetaTags.TagView do
       """
       def render_tag_og(tags) do
         [
-          tag(:meta, content: "website", property: "og:type"),
+          tag(:meta, content: get_tags_value(tags, "og:type", "og:type"), property: "og:type"),
           tag(:meta, content: get_tags_value(tags, "url", "og:url"), property: "og:url"),
           tag(:meta, content: get_tags_value(tags, "title", "og:title"), property: "og:title"),
           tag(:meta,
@@ -66,7 +66,7 @@ defmodule PhoenixMetaTags.TagView do
       """
       def render_tag_twitter(tags) do
         [
-          tag(:meta, content: "summary_large_image", name: "twitter:card"),
+          tag(:meta, content: get_tags_value(tags, "twitter:card", "twitter:card"), name: "twitter:card"),
           tag(:meta, content: get_tags_value(tags, "url", "twitter:url"), name: "twitter:url"),
           tag(:meta,
             content: get_tags_value(tags, "title", "twitter:title"),

--- a/test/phoenix_meta_tags_test.exs
+++ b/test/phoenix_meta_tags_test.exs
@@ -140,6 +140,28 @@ defmodule PhoenixMetaTagsTest do
       assert Enum.member?(tags_all, og_tag)
     end
 
+    test "test rewrite types of Open Graph and Twitter Card" do
+      tags = %{
+        title: "PhoenixTags;",
+        description: "PhoenixTags Blog",
+        url: "https://blog.PhoenixTags.com",
+        image: "https://images.unsplash.com/",
+        og: %{
+          type: "music.song"
+        },
+        twitter: %{
+          card: "summer"
+        }
+      }
+
+      og_tag = tag(:meta, content: "music.song", property: "og:type")
+      twitter_tag = tag(:meta, content: "summer", name: "twitter:card")
+
+      tags_all = render_tags_all(tags)
+      assert Enum.member?(tags_all, og_tag)
+      assert Enum.member?(tags_all, twitter_tag)
+    end
+
     test "test all tags - sets defaults for all meta tags" do
       tags = %{
         title: "PhoenixTags;",


### PR DESCRIPTION
Open Graph and Twitter Card come in different types. I add default values for them and made them optional.