### PR TITLE
Replace phoenix_html dependency with phoenix_html_helpers

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -6,47 +6,24 @@ env:
 
 # https://github.com/elixir-lang/elixir/blob/master/lib/elixir/pages/compatibility-and-deprecations.md
 jobs:
-  elixir_1_12:
+  format_and_unit_test:
     runs-on: ubuntu-20.04
     name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
     strategy:
       matrix:
-        otp: [22.x, 23.x, 24.x]
-        elixir: [1.12.x]
-    steps:
-      - uses: actions/checkout@v2
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: ${{matrix.otp}}
-          elixir-version: ${{matrix.elixir}}
-      - run: mix do deps.get, compile --warnings-as-errors
-      - run: mix format --dry-run --check-formatted
-      - run: mix test
-
-  elixir_1_11:
-    runs-on: ubuntu-20.04
-    name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
-    strategy:
-      matrix:
-        otp: [21.x, 22.x, 23.x, 24.x]
-        elixir: [1.11.x]
-    steps:
-      - uses: actions/checkout@v2
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: ${{matrix.otp}}
-          elixir-version: ${{matrix.elixir}}
-      - run: mix do deps.get, compile --warnings-as-errors
-      - run: mix format --dry-run --check-formatted
-      - run: mix test
-
-  elixir_1_10:
-    runs-on: ubuntu-20.04
-    name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
-    strategy:
-      matrix:
-        otp: [21.x, 22.x, 23.x]
-        elixir: [1.10.x]
+        include:
+          - elixir: "1.15"
+            otp: "26"
+          - elixir: "1.14"
+            otp: "25"
+          - elixir: "1.13"
+            otp: "24"
+          - elixir: "1.12"
+            otp: "23"
+          - elixir: "1.11"
+            otp: "22"
+          - elixir: "1.10"
+            otp: "21"
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,1 +1,1 @@
-use Mix.Config
+import Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :phoenix_meta_tags,
   title: "config_title",

--- a/lib/meta_tags/phoenix_meta_tags_view.ex
+++ b/lib/meta_tags/phoenix_meta_tags_view.ex
@@ -1,5 +1,4 @@
 defmodule PhoenixMetaTags.TagView do
-  use Phoenix.HTML
   alias PhoenixMetaTags.MapHelper
 
   @moduledoc """

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule PhoenixMetaTags.MixProject do
 
   defp deps do
     [
-      {:phoenix_html, "~> 2.10 or ~> 3.0"},
+      {:phoenix_html_helpers, "~> 1.0"},
       {:plug, "~> 1.7"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
     ]

--- a/test/map_helper_test.exs
+++ b/test/map_helper_test.exs
@@ -1,7 +1,7 @@
 defmodule MapHelerTest do
   use ExUnit.Case
   alias PhoenixMetaTags.MapHelper
-  use Phoenix.HTML
+  use PhoenixHTMLHelpers
 
   test "test map helper" do
     map = %{

--- a/test/phoenix_meta_tags_test.exs
+++ b/test/phoenix_meta_tags_test.exs
@@ -1,8 +1,9 @@
 defmodule PhoenixMetaTagsTest do
   use ExUnit.Case
+
+  use PhoenixHTMLHelpers
   use PhoenixMetaTags.TagView
 
-  import Phoenix.HTML.Tag
   doctest PhoenixMetaTags
 
   describe "render_tags_other/1" do


### PR DESCRIPTION
The latest version of `phoenix_html` package no longer includes `<tag>` and `<content_tag>` that `phoenix_meta_tags` uses.  Those functions have been moved to [phoenix_html_helpers](https://github.com/phoenixframework/phoenix_html_helpers).  Also see [changelog](https://github.com/phoenixframework/phoenix_html/blob/main/CHANGELOG.md#changelog) for recent changes.

This PR updates several things:
- use `phoenix_html_helpers` instead of `phoenix_html`
- use newer Config style (`import Config` vs `use Mix.Config`)
- update the CI unit test pipeline to include newer versions of elixir and OTP

NOTE: `phoenix_html_helpers` is dependent on `phoenix_html` version 4 as seen [in the mix file here](https://github.com/phoenixframework/phoenix_html_helpers/blob/5ec48c5d0ee391429cfa080a497b490ae455ccaa/mix.exs#L33).

